### PR TITLE
process proposal for adding/pinning down decisions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "fm-ledger-rules"]
+	path = fm-ledger-rules
+	url = https://github.com/input-output-hk/fm-ledger-rules

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,13 @@
+Copyright 2019 Input Output HK Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A repository for all concrete decisions made about how to implement the cardano
 blockchain. This repository contains all the technical details and improvements
-that is needed for the developers. The repository contains git submodules that
+that are needed for the developers. The repository contains git submodules that
 pin down specific versions of the formal specifications which these concrete
 technical decisions refer to. Changes to this need to be reflected in the
 different documents.
@@ -25,9 +25,9 @@ Proposals are to be made if:
 
 1. The formal specification is too vague and a concrete decision needs to be
    taken. Example: it is said the we take an index `idx` from the set of `Idx`.
-   However there is not specification wether it is acceptable to have negative
-   indices or if it is bounded (32bits? 64bits?), of if it is from 0 or from 1.
-   A proposal can be made to pin this down and guarantee that we are all talking
+   However it doesn't specify wether it is acceptable to have negative indices
+   or if it is bounded (32bits? 64bits?), of if it is from 0 or from 1. A
+   proposal can be made to pin this down and guarantee that we are all talking
    about the same thing.
 2. The current blockchain needs to include new features in order to implement the
    new feature defined by the formal spec. This needs to be documented here too.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,55 @@
-# implementation-decisions
-A repository for all concrete decisions made about how to implement the formal specs
+# implementation decisions
+
+A repository for all concrete decisions made about how to implement the
+cardano blockchain. This repository contains all the technical details
+and improvements that is needed for the developers.
+
+Regarding the formal specifications, the repository contains a git submodule
+that pin down a specific version of the formal specifications. Changes to
+this need to be reflected in the different documents.
+
+The "RFC" (request for comments) process is intended to provide a consistent
+and controlled path for new features to enter the blockchain and standard
+APIs, so that all stakeholders can be confident about the direction the
+blockchain is evolving in.
+
+# When to write a proposal
+
+Currently we only accept proposals and comments from within the IOHK
+organization.
+
+Proposals are to be made if:
+
+1. the formal specification is too vague and a concrete decision needs to be
+   taken. Example: it is said the we take an index `idx` from the set of `Idx`.
+   However there is not specification wether it is acceptable to have negative
+   indices or if it is bounded (32bits? 64bits?), of if it is from 0 or from 1.
+   A proposal can be made to pin this down and guarantee that we are all talking
+   about the same thing.
+2. the current blockchain needs to include new features in order to implement the
+   new feature defined by the formal spec. This needs to be documented here too.
+3. an improvement to the current implementation needs to be made. For example
+   one could propose an improvement to the way we serialize blocks.
+
+# The process
+
+1. fork this repository;
+2. Copy 0000-template.md to text/0000-my-feature.md (where "my-feature" is descriptive. don't assign an RFC number yet).
+3. Fill in the RFC;
+4. Submit a pull request. As a pull request the RFC will receive design feedback, and the author should be prepared to revise it in response
+5. The owners of this repository will orchestrate the review process. They will follow
+   the comments and will direct the conversation toward consensus. If no consensus can
+   be reach in a timely manner they may: close the PR or apply any changes they believe
+   to be necessary before merging the PR.
+
+# License
+
+This repository is currently in the process of being licensed under either of
+
+Apache License, Version 2.0, (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0)
+MIT license (LICENSE-MIT or http://opensource.org/licenses/MIT)
+at your option.
+
+# Contributions
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 # implementation decisions
 
-A repository for all concrete decisions made about how to implement the
-cardano blockchain. This repository contains all the technical details
-and improvements that is needed for the developers.
+A repository for all concrete decisions made about how to implement the cardano
+blockchain. This repository contains all the technical details and improvements
+that is needed for the developers. The repository contains git submodules that
+pin down specific versions of the formal specifications which these concrete
+technical decisions refer to. Changes to this need to be reflected in the
+different documents.
 
-Regarding the formal specifications, the repository contains a git submodule
-that pin down a specific version of the formal specifications. Changes to
-this need to be reflected in the different documents.
-
-The "RFC" (request for comments) process is intended to provide a consistent
-and controlled path for new features to enter the blockchain and standard
-APIs, so that all stakeholders can be confident about the direction the
-blockchain is evolving in.
+The "RFC" (request for comments) process is intended to provide a consistent and
+controlled path for new features to enter the blockchain and standard APIs, so
+that all stakeholders can be confident about the direction the blockchain is
+evolving in. It's also intended as an explicit list of concrete decisions that
+are outside the scope of the abstract specifications, and therefore the weight
+of the decision making should lie with the party making the proposal (who will
+more than likely be involved in a concrete implementation at the time of making
+it).
 
 # When to write a proposal
 
@@ -20,27 +23,30 @@ organization.
 
 Proposals are to be made if:
 
-1. the formal specification is too vague and a concrete decision needs to be
+1. The formal specification is too vague and a concrete decision needs to be
    taken. Example: it is said the we take an index `idx` from the set of `Idx`.
    However there is not specification wether it is acceptable to have negative
    indices or if it is bounded (32bits? 64bits?), of if it is from 0 or from 1.
    A proposal can be made to pin this down and guarantee that we are all talking
    about the same thing.
-2. the current blockchain needs to include new features in order to implement the
+2. The current blockchain needs to include new features in order to implement the
    new feature defined by the formal spec. This needs to be documented here too.
-3. an improvement to the current implementation needs to be made. For example
+3. An improvement to the current implementation needs to be made. For example
    one could propose an improvement to the way we serialize blocks.
 
 # The process
 
 1. fork this repository;
-2. Copy 0000-template.md to text/0000-my-feature.md (where "my-feature" is descriptive. don't assign an RFC number yet).
+2. Copy <XXX-template.md> to `text/0000-my-feature.md` (where "my-feature" is
+   descriptive. don't assign an RFC number yet).
 3. Fill in the RFC;
-4. Submit a pull request. As a pull request the RFC will receive design feedback, and the author should be prepared to revise it in response
-5. The owners of this repository will orchestrate the review process. They will follow
-   the comments and will direct the conversation toward consensus. If no consensus can
-   be reach in a timely manner they may: close the PR or apply any changes they believe
-   to be necessary before merging the PR.
+4. Submit a pull request and fill in the `RFC PR:` section in
+   <./XXXX-template.md>. As a pull request the RFC will receive design feedback,
+   and the author should be prepared to revise it in response
+5. The owners of this repository will orchestrate the review process. They will
+   follow the comments and will direct the conversation toward consensus. If no
+   consensus can be reached in a timely manner they may: close the PR or apply
+   any changes they believe to be necessary before merging the PR.
 
 # License
 

--- a/XXXX-template.md
+++ b/XXXX-template.md
@@ -13,7 +13,7 @@ One paragraph explanation of the feature.
 Why are we doing this? What use cases does it support? What is the expected outcome?
 
 # Decision
-[guide-level-explanation]: #guide-level-explanation
+[Decision]: #decision
 
 Explain the proposal as if it was already included in the blockchain and you
 were teaching it to someone else. That generally means:
@@ -22,7 +22,7 @@ were teaching it to someone else. That generally means:
 - Explaining the feature largely in terms of examples.
 
 # Technical explanation
-[reference-level-explanation]: #reference-level-explanation
+[technical-explanation]: #technical-explanation
 
 This is the detailed technical portion of the RFC. Explain the design in
 sufficient detail that:
@@ -34,7 +34,8 @@ sufficient detail that:
 The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
 
 # Drawbacks/Implications
-[drawbacks]: #drawbacks
+[drawbacks]: #drawbacksimplications
+[implications]: #drawbacksimplications
 
 Why should we *not* do this?
 

--- a/XXXX-template.md
+++ b/XXXX-template.md
@@ -12,7 +12,7 @@ One paragraph explanation of the feature.
 
 Why are we doing this? What use cases does it support? What is the expected outcome?
 
-# Guide-level explanation
+# Decision
 [guide-level-explanation]: #guide-level-explanation
 
 Explain the proposal as if it was already included in the blockchain and you
@@ -21,10 +21,11 @@ were teaching it to someone else. That generally means:
 - Introducing new named concepts.
 - Explaining the feature largely in terms of examples.
 
-# Reference-level explanation
+# Technical explanation
 [reference-level-explanation]: #reference-level-explanation
 
-This is the technical portion of the RFC. Explain the design in sufficient detail that:
+This is the detailed technical portion of the RFC. Explain the design in
+sufficient detail that:
 
 - Its interaction with other features is clear.
 - It is reasonably clear how the feature would be implemented.
@@ -32,7 +33,7 @@ This is the technical portion of the RFC. Explain the design in sufficient detai
 
 The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
 
-# Drawbacks
+# Drawbacks/Implications
 [drawbacks]: #drawbacks
 
 Why should we *not* do this?

--- a/XXXX-template.md
+++ b/XXXX-template.md
@@ -1,0 +1,56 @@
+- Feature Name: (fill me in with a unique ident, my_awesome_feature)
+- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- RFC PR: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+One paragraph explanation of the feature.
+
+# Motivation
+[motivation]: #motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+Explain the proposal as if it was already included in the blockchain and you
+were teaching it to someone else. That generally means:
+
+- Introducing new named concepts.
+- Explaining the feature largely in terms of examples.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+This is the technical portion of the RFC. Explain the design in sufficient detail that:
+
+- Its interaction with other features is clear.
+- It is reasonably clear how the feature would be implemented.
+- Corner cases are dissected by example.
+
+The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+
+# Prior art
+[prior-art]: #prior-art
+
+Discuss prior art, both the good and the bad, in relation to this proposal.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?


### PR DESCRIPTION
This is to propose what the process could be to pin down the decision regarding what is present in the formal spec and to propose improvements to the current blockchain implementation.

For reference, I've based my thoughts on what rust lang is using for their RFCs process. I've tried to keep things open so that this repository can continue to be a central point of exchange for the developers to propose changes. I also believe this is good to keep things in the same place: one place to refer from.

May I also suggest we rename this repository to something more generic cardano-improvement-proposal ?

closes #1, succeeds #9